### PR TITLE
Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ It will show the result above status bar:
 
 ### 1. Prepare the cast script
 
-I haven't write the Eclipse plugin yet, so if you need to use it on a eclipse project, you can try to use the command line.
+I haven't written the Eclipse plugin yet, so if you need to use it on a eclipse project, you can try to use the command line.
 
 You can get the script here <https://raw.githubusercontent.com/mmin18/LayoutCast/master/cast.py>. Put the script in project root dir or anywhere you like. Since it is written in Python 2.7 (make sure you have installed the right version). 
 
@@ -127,13 +127,13 @@ Or you can specify the path in args:
 
 ## How it Works
 
-When **LayoutCast.init(context);**, the application will start tiny http server in the background, and receive certain commands. Later on, the cast script running on your computer will communicate with your running app which is running through ADB TCP forward.
+When **LayoutCast.init(context);** called, the application will start tiny http server in the background, and receive certain commands. Later on, the cast script running on your computer will communicate with your running app which is running through ADB TCP forward.
 
-When the cast script runs, it will scan all possible ports on your phone to find the running LayoutCast server, and get the running application's resource list with its id, then compiled to `public.xml` that will be used later to keep resource id index consistent with the running application.
+When the cast script runs, it will scan all possible ports on your phone to find the running LayoutCast server, and get the running application's resource list with its id, then compiled to `public.xml`. In which, it will be used later to keep resource id index consistent with the running application.
 
-The cast script scans your project folder to find the `/res` folder, and all dependencies inside `/res` folder. You can run the **aapt** command to package all resources into **res.zip**, and then upload the zip file to the LayoutCast server to replace the resources of the running process. Then it calls the **Activity.recreate()** to restart the visible activity.
+The cast script scans your project folder to find the `/res` folder, and all dependencies inside `/res` folder. You can run the **aapt** command to package all resources into **res.zip**, and then upload the zip file to the LayoutCast server to replace the resources of the running process. Then, it calls the **Activity.recreate()** to restart the visible activity.
 
-Usually the activity will keep its running state in **onSaveInstanceState()** and restores after coming back later.
+Usually the activity will keep its running state in **onSaveInstanceState()** and restore after coming back later.
 
 ## Troubleshootings
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
 
 ## Motivation
 
-Facebook Buck <http://github.com/facebook/buck> build is fast. In some cases, it is faster than LayoutCast due to its multi-process build. The biggest problem with Buck is, it requires you to change a lot of codes, and restructs your project in small modules. Indeed, it is troublesome to just make it work properly on the existing android project, especially if you have big project. I have tried using Buck build system instead of Gradle on my test project. However, it took me a week just to make it work.
+Facebook Buck <http://github.com/facebook/buck> build is fast. However, the biggest problem with Buck is, it requires you to change a lot of codes, and restructs your project in small modules. Indeed, it is troublesome to just make it work properly on the existing android project, especially if you have big project. I have tried using Buck build system instead of Gradle on my test project. However, it took me a week just to make it work.
 
-What I needs is a build tool that is easy to setup, fast as Buck, and provide a Run button in AndroidStudio. So I created LayoutCast.
+What I needs is a build tool that is easy to setup, fast as Buck, and provide a Run button in Android Studio. So I created LayoutCast.
 
-LayoutCast is a little tool to help with that, it will cast every changes in your Java source code or resources (including library project) to your phone or emulator within 5 sec, and does not restart your application.
+**LayoutCast** is a little tool to help with that, it will cast every changes in your Java source code or resources (including library project) to your phone or emulator within 5 sec, and does not restart your application.
 
 把代码和资源文件的改动直接同步到手机上，应用不需要重启。省去了编译运行漫长的等待，比较适合真机调试的时候使用。
 
@@ -40,13 +40,13 @@ The test machine is a 2015 MBP with a 2014 MotoX.
 
 The test project's apk is about 14.3MB, which contains 380k lines of java code and 86k lines of xml files.
 
-## Get Started for AndroidStudio/Intellij
+## Getting Started for Android Studio / Intellij
 
 ### 1. Install Plugin
 
 *If you have already done that, you can skip this step.*
 
-1. Download Android Studio/Intellij <https://github.com/mmin18/LayoutCast/raw/master/ide/IDEAPlugin/IDEAPlugin.jar>
+1. Download Android Studio / Intellij plugin <https://github.com/mmin18/LayoutCast/raw/master/ide/IDEAPlugin/IDEAPlugin.jar>
 2. In Android Studio, go to `Preferences` > `Plugins` > `Install plugin from disk...`
 3. Choose the downloaded file from step #1 to install the plugin.
 
@@ -80,11 +80,11 @@ After restart, you should find a button at right of the run section: ![TOOLBAR](
         android:name=".MyApplication"
 		...
 
-**Fourth,** add an activity in your manifest, this is only used to reset the running process to make the application restart and restore its activity stack.
+**Fourth,** add special activity class (from LayoutCast library) called `ResetActivity` in your manifest, this activity will be used to restart and restore our application activity stack.
 
 	<activity android:name="com.github.mmin18.layoutcast.ResetActivity" />
 
-And make sure you have the network permission in your AndroidManifest.xml:
+And make sure you have the network permission in your `AndroidManifest.xml`:
 
     <uses-permission android:name="android.permission.INTERNET" />
 
@@ -100,7 +100,7 @@ It will show the result above status bar:
 
 ![FAIL](images/sc_fail.png)
 
-## Get started for Eclipse
+## Getting started for Eclipse
 
 ### 1. Prepare the cast script
 
@@ -135,9 +135,9 @@ The cast script scans your project folder to find the `/res` folder, and all dep
 
 Usually the activity will keep its running state in **onSaveInstanceState()** and restores after coming back later.
 
-## Troubleshooting
+## Troubleshootings
 
 - It can only find `/src` folder under `<project>/src` or `<project>/src/main/src`
 - It can only find `/res` folder under `<project>/res` or `<project>/src/main/res`
-- You can add new or replace resources, but you can't delete or rename resources (for now)
+- You can add or replace resources, but you can't delete or rename resources (for now)
 - If cast failed, clean your project, remove `/bin` and `/build` and rebuild again may solve the problem


### PR DESCRIPTION
I have evaluated my own changes and added more fixes to my previous changes.

1. Fix illogical motivation content sentences.
2. Fix grammar 'Get Started' to 'Getting Started', 'I haven't write' to 'I haven't written'
3. Add space from 'AndroidStudio'  to 'Android Studio'
4. Make 'LayoutCast' text bold to emphasise the project title.
5. Clear up step number 1 for Android Studio installation -> missing *plugin* word.