### PR TITLE
执行layoutCast插件时出现找不到资源的错误

### DIFF
--- a/cast.py
+++ b/cast.py
@@ -759,7 +759,7 @@ if __name__ == "__main__":
         aaptargs.append('-S')
         aaptargs.append(binresdir)
 
-        # Error Fix - roger
+        #Set apcompat and design android library's res
         exporesdir = os.path.join(dir, 'build', 'intermediates', 'exploded-aar')
         aaptargs.append('-S')
         aaptargs.append(os.path.join(exporesdir, 'com.android.support/appcompat-v7/23.0.1/res'))

--- a/cast.py
+++ b/cast.py
@@ -758,6 +758,14 @@ if __name__ == "__main__":
         aaptargs = [aaptpath, 'package', '-f', '--auto-add-overlay', '-F', os.path.join(bindir, 'res.zip')]
         aaptargs.append('-S')
         aaptargs.append(binresdir)
+
+        # Error Fix - roger
+        exporesdir = os.path.join(dir, 'build', 'intermediates', 'exploded-aar')
+        aaptargs.append('-S')
+        aaptargs.append(os.path.join(exporesdir, 'com.android.support/appcompat-v7/23.0.1/res'))
+        aaptargs.append('-S')
+        aaptargs.append(os.path.join(exporesdir, 'com.android.support/design/23.0.1/res'))
+
         rdir = resdir(dir)
         if rdir:
             aaptargs.append('-S')


### PR DESCRIPTION
对于#2。 我用gradle，在android studio中使用插件。但是会出现资源找不到的问题。排查原因是因为缺少appcompat以及design路径，加上后，脚本执行，可以解决。

但是由于python不熟。版本写死了，请屠大师看看怎么修改？
